### PR TITLE
Interim radargram image no long created in notebooks directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 
 # Run test
 script:
-  - nosetests $TEST_DIR -v -s
+  - travis_wait 20 nosetests $TEST_DIR -v -s
 
 notifications:
   slack: ubcgif:1Z2lR3XYRSM3GHflG71ZHEN6

--- a/Notebooks/GPR_Lab6_FitData.ipynb
+++ b/Notebooks/GPR_Lab6_FitData.ipynb
@@ -63,18 +63,9 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Downloading http://github.com/geoscixyz/gpgLabs/raw/master/figures/GPR/ubc_GPRdata.png\n",
-      "   saved to: C:\\Users\\Devin\\Documents\\GPGlabs\\notebooks\\ubc_GPRdata.png\n",
-      "Download completed!\n"
-     ]
-    },
-    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cc6ed9543d7f44a7b23e1bfeafc7f59d"
+       "model_id": "94b533cad0a54e598df4e27ade6ebe50"
       }
      },
      "metadata": {},
@@ -92,8 +83,8 @@
     }
    ],
    "source": [
-    "radargramImagePath = \"http://github.com/geoscixyz/gpgLabs/raw/master/figures/GPR/ubc_GPRdata.png\"\n",
-    "radargramImage = download(radargramImagePath,overwrite=True,verbose=False)\n",
+    "URL = \"http://github.com/geoscixyz/gpgLabs/raw/master/figures/GPR/ubc_GPRdata.png\"\n",
+    "radargramImage = downloadRadargramImage(URL)\n",
     "PipeWidget(radargramImage)"
    ]
   },
@@ -117,24 +108,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {
     "scrolled": true
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Downloading http://github.com/geoscixyz/gpgLabs/raw/master/figures/GPR/ubc_GPRdata.png\n",
-      "   saved to: C:\\Users\\Devin\\Documents\\GPGlabs\\notebooks\\ubc_GPRdata.png\n",
-      "Download completed!\n"
-     ]
-    },
-    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8db9b8cc34f44b068c390baa85ce9635"
+       "model_id": "9b6c195504c14ea38c09ac60dd1cc3c6"
       }
      },
      "metadata": {},
@@ -146,14 +128,14 @@
        "<function gpgLabs.GPR.GPRlab1.WallWidgetFcn>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "radargramImagePath = \"http://github.com/geoscixyz/gpgLabs/raw/master/figures/GPR/ubc_GPRdata.png\"\n",
-    "radargramImage = download(radargramImagePath,overwrite=True,verbose=False)\n",
+    "URL = \"http://github.com/geoscixyz/gpgLabs/raw/master/figures/GPR/ubc_GPRdata.png\"\n",
+    "radargramImage = downloadRadargramImage(URL)\n",
     "WallWidget(radargramImage)"
    ]
   },

--- a/gpgLabs/GPR/GPRlab1.py
+++ b/gpgLabs/GPR/GPRlab1.py
@@ -8,6 +8,24 @@ from ipywidgets import interact, interactive, IntSlider, widget, FloatText, Floa
 
 from .Wiggle import wiggle, PrimaryWave, ReflectedWave
 
+import requests
+from io import BytesIO
+
+
+########################################
+#           DOWNLOAD FUNCTIONS
+########################################
+
+def downloadRadargramImage(URL):
+
+    urlObj = requests.get(URL)
+    imgcmp = Image.open(BytesIO(urlObj.content))
+
+    return imgcmp
+
+
+
+
 ########################################
 #           WIDGETS
 ########################################
@@ -43,21 +61,23 @@ def PipeWidget(radargramImage):
             h=(0.1, 2.0, 0.1),
             xc=(0., 40., 0.2),
             r=(0.1, 3, 0.1),
-            dataImage=fixed(radargramImage))
+            imgcmp=fixed(radargramImage))
 
     return i
 
 
-def WallWidget(radargramImage):
+def WallWidget(radargramImagePath):
 
     i = interact(WallWidgetFcn,
             epsr = (0, 100, 1),
             h=(0.1, 2.0, 0.1),
             x1=(1, 35, 1),
             x2=(20, 40, 1),
-            dataImage=fixed(radargramImage))
+            imgcmp=fixed(radargramImagePath))
 
     return i
+
+
 
 
 ########################################
@@ -121,8 +141,9 @@ def PrimaryFieldWidgetFcn(tinterp, epsr, radgramImg):
     plt.show()
 
 
-def PipeWidgetFcn(epsr, h, xc, r, dataImage):
-    imgcmp = Image.open(dataImage)
+def PipeWidgetFcn(epsr, h, xc, r, imgcmp):
+
+    # imgcmp = Image.open(dataImage)
     imgcmp = imgcmp.resize((600, 800))
     fig = plt.figure(figsize = (9,11))
     ax = plt.subplot(111)
@@ -143,8 +164,9 @@ def PipeWidgetFcn(epsr, h, xc, r, dataImage):
     plt.show()
 
 
-def WallWidgetFcn(epsr, h, x1, x2, dataImage):
-    imgcmp = Image.open(dataImage)
+def WallWidgetFcn(epsr, h, x1, x2, imgcmp):
+
+    # imgcmp = Image.open(dataImage)
     imgcmp = imgcmp.resize((600, 800))
     fig = plt.figure(figsize = (9,11))
     ax = plt.subplot(111)


### PR DESCRIPTION
simpeg's "download" function saves a copy of the downloaded file in the working directory. I found a way to get around this.